### PR TITLE
Add in ability to pass arguments to the kivy app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ options:
   -b BLACKLIST [BLACKLIST ...], --blacklist BLACKLIST [BLACKLIST ...]
                         exclude specific files/dirs from being monitored.
   -V, --version         show program's version number and exit
+  --app-args    arguments to pass to the kivy application as a single quoted string, this will be split and passed on to the kivy application, example --app-args "arg1 arg2 --my-kwarg=value"
 ```
 
 *(Works on windows, linux and osx)*

--- a/kvhot/__main__.py
+++ b/kvhot/__main__.py
@@ -39,7 +39,7 @@ def parse_args():
     )
     parser.add_argument(
         "target_dir",
-        # type=check_target_dir,
+        type=check_target_dir,
         help="directory of the entry-point (main.py) of the kivy application",
     )
     parser.add_argument("--width", type=int, default=350, help="width of the window.")

--- a/kvhot/__main__.py
+++ b/kvhot/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib.metadata
 import os
+import shlex
 import subprocess
 import sys
 from typing import Union
@@ -30,37 +31,40 @@ def check_target_dir(path: str) -> str:
     return path
 
 
-parser = argparse.ArgumentParser(
-    prog="kvhot",
-    description="Automatically restarts the Kivy application "
-    "whenever files within the project directory change.",
-)
-parser.add_argument(
-    "target_dir",
-    type=check_target_dir,
-    help="directory of the entry-point (main.py) of the kivy application",
-)
-parser.add_argument(
-    "--width", type=int, default=350, help="width of the window."
-)
-parser.add_argument(
-    "--height", type=int, default=650, help="height of the window."
-)
-parser.add_argument(
-    "--top", type=int, default=0, help="top position of the window."
-)
-parser.add_argument(
-    "--left", type=int, default=0, help="left position of the window."
-)
-parser.add_argument(
-    "-b",
-    "--blacklist",
-    nargs="+",
-    help="exclude specific files/dirs from being monitored.",
-)
-parser.add_argument(
-    "-V", "--version", action="version", version="%(prog)s " + __version__
-)
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="kvhot",
+        description="Automatically restarts the Kivy application "
+        "whenever files within the project directory change.",
+    )
+    parser.add_argument(
+        "target_dir",
+        # type=check_target_dir,
+        help="directory of the entry-point (main.py) of the kivy application",
+    )
+    parser.add_argument("--width", type=int, default=350, help="width of the window.")
+    parser.add_argument("--height", type=int, default=650, help="height of the window.")
+    parser.add_argument("--top", type=int, default=0, help="top position of the window.")
+    parser.add_argument("--left", type=int, default=0, help="left position of the window.")
+    parser.add_argument(
+        "-b",
+        "--blacklist",
+        nargs="+",
+        help="exclude specific files/dirs from being monitored.",
+    )
+    parser.add_argument("-V", "--version", action="version", version="%(prog)s " + __version__)
+
+    # Arbitrary arguments to pass through to the kivy application
+    parser.add_argument(
+        "--app-args",
+        help="arguments to pass to the kivy application as a single quoted string, this will be split and passed on to the kivy application",
+    )
+    args = parser.parse_args()
+    if args.app_args:
+        args.app_args = shlex.split(args.app_args)
+    else:
+        args.app_args = []
+    return args
 
 
 def log(s: str):
@@ -114,12 +118,14 @@ class Watcher:
         top: int,
         left: int,
         blacklist: Union[list[str], None],
+        app_args: list,
     ):
         self.target_dir = target_dir
         self.main_py = os.path.join(self.target_dir, "main.py")
         self.blacklist_filter = DefaultFilter(
             ignore_paths=filter_blacklist_paths(blacklist)
         )
+        self.app_args = app_args
 
         os.environ["KCFG_GRAPHICS_WIDTH"] = str(width)
         os.environ["KCFG_GRAPHICS_HEIGHT"] = str(height)
@@ -140,7 +146,8 @@ class Watcher:
             log(f"{change_type} {file_path}, restarting app...")
             self._process.kill()
 
-        self._process = subprocess.Popen([sys.executable, self.main_py])
+        command = [sys.executable, self.main_py] + self.app_args
+        self._process = subprocess.Popen(command)
 
     def _stop_app(self):
         if self._process:
@@ -164,7 +171,8 @@ class Watcher:
 
 
 def main():
-    args = vars(parser.parse_args())
+    args = parse_args()
+    args = vars(args)
     w = Watcher(**args)
     w.start()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'kvhot'
-version = 'v2024.02.07'
+version = 'v2024.09.12'
 description = 'Automatically restarts the Kivy application whenever files within the project directory change.'
 readme = 'README.md'
-authors = [{ name = 'Kulothungan U.G', email = 'kulothunganug@gmail.com' }]
+authors = [{ name = 'Kulothungan U.G', email = 'kulothunganug@gmail.com' }, { name = 'Alexander Hellier', email = 'alex.hellier@gmail.com' }]
 license = { file = 'LICENSE' }
 keywords = ['kivy', 'kivymd', 'hotrestart', 'gui']
 dependencies = [


### PR DESCRIPTION
Currently you cannot pass any additional arguments to the kivy app (such as a data directory, log location etc)

This update allows the user to send in --app-args which will be additionally parsed and sent to the kivy app for it to use.